### PR TITLE
Alternative connection matrix representation

### DIFF
--- a/graph.js
+++ b/graph.js
@@ -31,9 +31,9 @@ BitcoinGraph.prototype = {
         for (const a of sorted) {
             s = lpad(map[a.port], 4);
             for (const b of sorted) {
-                let z = '--';
-                if (a.port !== b.port) {
-                    z = (a.isConnected(b) ? 'o' : 'x') + (b.isConnected(a) ? 'o' : 'x');
+                let z = '-';
+                if (a.port !== b.port && (a.isConnected(b) || b.isConnected(a))) {
+                    z = '⤴';
                 }
                 s += lpad(z, 4);
             }


### PR DESCRIPTION
Use unicode char ⤴  to show direction of connection
in printed nxn connectivity matrix. Each cell either contains
the arrow showing direction of connection or '-' which means 
there is no connection.